### PR TITLE
update(streamcard): show whole link on a mouseover

### DIFF
--- a/src/components/StreamCard.tsx
+++ b/src/components/StreamCard.tsx
@@ -92,6 +92,7 @@ export function StreamCard({ stream }: StreamCardProps) {
                   rel="noopener noreferrer"
                   className="text-sm text-purple-300 hover:text-purple-200 block 
                            whitespace-nowrap overflow-hidden text-ellipsis"
+                  title={link}
                 >
                   {link}
                 </a>


### PR DESCRIPTION
Have the whole link be readable on mouseover to ease the users browsing

![image](https://github.com/user-attachments/assets/362c54e6-8e63-4cc6-86fc-15a4ead7849f)
